### PR TITLE
Update description in help dialog

### DIFF
--- a/src/wd_fw_update/main.py
+++ b/src/wd_fw_update/main.py
@@ -34,7 +34,7 @@ def parse_args(args):
     Returns:
       :obj:`argparse.Namespace`: command line parameters namespace
     """
-    parser = argparse.ArgumentParser(description="Just a Fibonacci demonstration")
+    parser = argparse.ArgumentParser(description="CLI tool to find and update firmware for WD nvme drives")
     parser.add_argument(
         "--version",
         action="version",


### PR DESCRIPTION
This is what the help would show previously:

```
$ wd_fw_update -h
usage: wd_fw_update [-h] [--version] [-v] [-vv]

Just a Fibonacci demonstration

options:
  -h, --help           show this help message and exit
  --version            show program's version number and exit
  -v, --verbose        set loglevel to INFO
  -vv, --very-verbose  set loglevel to DEBUG
```

Now it no longer claims to be a fibbonaci demonstration...